### PR TITLE
feat: 게시글 좋아요 사용자 목록 팝업 추가

### DIFF
--- a/src/components/search/SearchComponent.js
+++ b/src/components/search/SearchComponent.js
@@ -135,7 +135,8 @@ const SearchComponent = ({ data, onSearchResults }) => {
       }}>
         <FormControl 
           size="small"
-          sx={{ width: 120 }}
+          sx={{ width: 120,
+           }}
         >
           <Select
             value={searchCategory}


### PR DESCRIPTION
## 변경 사항
- 게시글의 좋아요 수 클릭시 좋아요한 사용자 목록을 보여주는 팝업 추가
- 사용자 프로필 이미지와 이름을 포함한 목록 구현
- 리스트 항목 클릭시 해당 사용자의 프로필 페이지로 이동
- 목록이 길어질 경우 스크롤 가능하도록 구현
- 좋아요가 있는 경우에만 클릭 가능하도록 UX 개선

## 스크린샷
![image](https://github.com/user-attachments/assets/240fd5ed-1227-42e2-9958-e6361bd7386c)
![image](https://github.com/user-attachments/assets/86780204-93db-4046-abe5-0c9c95a7b2c9)

## 테스트 항목
- [x] 좋아요한 사용자 목록이 정확하게 표시되는지 확인
- [x] 좋아요가 있는 경우에만 팝업이 열리는지 확인
- [ ] 여러 사용자가 좋아요했을 때 스크롤이 정상 작동하는지 확인
- [x] 사용자 프로필 페이지 이동이 정상 작동하는지 확인
- [ ] 전체적인 스타일링과 반응형 디자인 확인