### PR TITLE
썸네일 이미지 표시 개선 및 마크다운 이미지 활용 기능

### DIFF
--- a/src/components/auth/SignIn.js
+++ b/src/components/auth/SignIn.js
@@ -13,11 +13,13 @@ import {
   IconButton,
   InputAdornment,
   useTheme,
-  useMediaQuery
+  useMediaQuery,
+  CircularProgress
 } from '@mui/material';
 import { Chrome, EyeOff, Eye, Mail, Lock } from 'lucide-react';
 import { Link as RouterLink, useNavigate } from 'react-router-dom';
 import { useAuth } from './AuthContext';
+import AnimatedLoading from '../common/AnimatedLoading'; // 추가된 import
 
 const AJOU_BLUE = '#0A2B5D';
 
@@ -27,6 +29,7 @@ export const SignIn = () => {
   const [error, setError] = useState('');
   const [role, setRole] = useState(0); // 0: 학생,교수, 1: 기업
   const [showPassword, setShowPassword] = useState(false);
+  const [loading, setLoading] = useState(false); // 로딩 상태 추가
   const { login, loginWithGoogle } = useAuth();
   const navigate = useNavigate();
   const theme = useTheme();
@@ -43,11 +46,15 @@ export const SignIn = () => {
       setError('기업 회원만 이메일 로그인이 가능합니다.');
       return;
     }
+    
     try {
+      setLoading(true); // 로딩 시작
       await login(email, password);
       navigate('/');  
     } catch (error) {
       setError('로그인에 실패했습니다. 이메일과 비밀번호를 확인해주세요.');
+    } finally {
+      setLoading(false); // 로딩 완료
     }
   };
 
@@ -56,13 +63,22 @@ export const SignIn = () => {
       setError('기업 회원은 이메일로 로그인해주세요.');
       return;
     }
+    
     try {
+      setLoading(true); // 로딩 시작
       await loginWithGoogle();
       navigate('/');  
     } catch (error) {
       setError('Google 로그인에 실패했습니다.');
+    } finally {
+      setLoading(false); // 로딩 완료
     }
   };
+
+  // 전체 페이지 로딩 UI 표시
+  if (loading) {
+    return <AnimatedLoading message="로그인 처리 중입니다" fullPage={true} />;
+  }
 
   const renderLoginForm = () => {
     if (role === 1) { // 기업 로그인

--- a/src/components/card/ContentCard.js
+++ b/src/components/card/ContentCard.js
@@ -12,6 +12,7 @@ const ContentCard = ({
   title, 
   description, 
   image, 
+  content,  // 추가: 마크다운 콘텐츠
   likeCount: initialLikeCount = 0, 
   commentCount = 0,
   type = 'portfolio', // 'portfolio', 'company', 'lab'
@@ -37,16 +38,49 @@ const ContentCard = ({
     currentUser?.uid || null
   );
 
+  // 마크다운 내용에서 첫 번째 이미지 URL 추출
+  const extractFirstImageFromMarkdown = (markdownContent) => {
+    if (!markdownContent) return null;
+    
+    // 마크다운 이미지 형식 ![alt](url) 또는 <img src="url"> 패턴 찾기
+    const markdownImageRegex = /!\[.*?\]\((.*?)\)/;
+    const htmlImageRegex = /<img.*?src=["'](.*?)["']/;
+    
+    const markdownMatch = markdownContent.match(markdownImageRegex);
+    const htmlMatch = markdownContent.match(htmlImageRegex);
+    
+    // 마크다운 형식 이미지 우선, 없으면 HTML 형식 이미지 사용
+    if (markdownMatch && markdownMatch[1]) {
+      return markdownMatch[1];
+    } else if (htmlMatch && htmlMatch[1]) {
+      return htmlMatch[1];
+    }
+    
+    return null;
+  };
+
   // 이미지 처리
   const getDisplayImage = () => {
     // 1. 기존 썸네일 이미지가 있으면 사용
-    if (image) return image;
+    if (image && image !== 'markdown-image') return image;
     
     // 2. 첨부 파일 중 이미지가 있으면 첫 번째 이미지 사용
     const imageFile = files?.find(file => file.type === 'IMAGE' && file.url);
     if (imageFile) return imageFile.url;
     
-    // 3. 기본 이미지 사용
+    // 3. 'markdown-image'인 경우 content에서 이미지 추출
+    if (image === 'markdown-image' && content) {
+      const markdownImage = extractFirstImageFromMarkdown(content);
+      if (markdownImage) return markdownImage;
+    }
+    
+    // 4. 마크다운 내용에서 이미지 추출 (내용이 있는 경우)
+    if (content) {
+      const markdownImage = extractFirstImageFromMarkdown(content);
+      if (markdownImage) return markdownImage;
+    }
+    
+    // 5. 기본 이미지 사용
     return `/default-img.png`;
   };
 

--- a/src/components/posts/upload/FileUploader.js
+++ b/src/components/posts/upload/FileUploader.js
@@ -1,0 +1,103 @@
+import React from 'react';
+import { 
+  Typography, 
+  Box, 
+  Button, 
+  List, 
+  ListItem, 
+  IconButton, 
+  TextField 
+} from '@mui/material';
+import {
+  CloudUpload as UploadIcon,
+  Close as CloseIcon
+} from '@mui/icons-material';
+
+/**
+ * 파일 업로더 컴포넌트
+ */
+const FileUploader = ({ files, onAddFiles, onUpdateDescription, onRemoveFile }) => {
+  const handleFileChange = (e) => {
+    const selectedFiles = Array.from(e.target.files);
+    
+    selectedFiles.forEach(file => {
+      const fileType = file.type.startsWith('image/') ? 'IMAGE' 
+                      : file.type === 'application/pdf' ? 'PDF' 
+                      : 'DOC';
+      
+      onAddFiles({
+        fileId: `file-${Date.now()}-${Math.random()}`,
+        file: file,
+        type: fileType,
+        description: ''
+      });
+    });
+  };
+
+  return (
+    <Box sx={{ mb: 4 }}>
+      <Typography variant="h6" gutterBottom>
+        파일 첨부
+      </Typography>
+      <Button
+        component="label"
+        variant="outlined"
+        startIcon={<UploadIcon />}
+        sx={{ mb: 2 }}
+      >
+        파일 선택
+        <input
+          type="file"
+          hidden
+          multiple
+          onChange={handleFileChange}
+        />
+      </Button>
+
+      {files.length > 0 && (
+        <List>
+          {files.map((file) => (
+            <ListItem 
+              key={file.fileId}
+              sx={{ 
+                bgcolor: 'grey.50',
+                borderRadius: 1,
+                mb: 1,
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'stretch'
+              }}
+            >
+              <Box sx={{ 
+                display: 'flex', 
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                width: '100%'
+              }}>
+                <Typography>
+                  {file.filename || file.file.name}
+                </Typography>
+                <IconButton 
+                  onClick={() => onRemoveFile(file.fileId)}
+                  sx={{ color: 'error.main' }}
+                >
+                  <CloseIcon />
+                </IconButton>
+              </Box>
+              <TextField
+                fullWidth
+                size="small"
+                placeholder="파일 설명 입력"
+                value={file.description || ''}
+                onChange={(e) => onUpdateDescription(file.fileId, e.target.value)}
+                sx={{ mt: 1 }}
+              />
+            </ListItem>
+          ))}
+        </List>
+      )}
+    </Box>
+  );
+};
+
+export default FileUploader;

--- a/src/components/posts/upload/KeywordInput.js
+++ b/src/components/posts/upload/KeywordInput.js
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import { 
+  Typography, 
+  Box, 
+  TextField, 
+  Chip 
+} from '@mui/material';
+
+/**
+ * 키워드 입력 컴포넌트
+ */
+const KeywordInput = ({ keywords, onAdd, onDelete }) => {
+  const [newKeyword, setNewKeyword] = useState('');
+
+  const handleKeywordAdd = (e) => {
+    // IME 입력 중인 경우 처리하지 않음 (한국어, 일본어 등)
+    if (e.type === 'keydown' && e.nativeEvent.isComposing) {
+      return;
+    }
+    
+    // 엔터키 입력 시 키워드 추가
+    if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+      e.preventDefault();
+      
+      if (newKeyword.trim()) {
+        const trimmedKeyword = newKeyword.trim().toLowerCase();
+        
+        // 중복 키워드가 아닌 경우에만 추가
+        if (!keywords.includes(trimmedKeyword)) {
+          onAdd(trimmedKeyword);
+          setNewKeyword('');
+        }
+      }
+    }
+  };
+
+  return (
+    <Box sx={{ mb: 4 }}>
+      <Typography variant="h6" gutterBottom>
+        키워드
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        사용한 기술 스택이나 주요 키워드를 입력해주세요. (Enter로 추가)
+      </Typography>
+      <TextField
+        fullWidth
+        value={newKeyword}
+        onChange={(e) => setNewKeyword(e.target.value)}
+        onKeyDown={handleKeywordAdd}
+        placeholder="키워드 입력 후 Enter"
+        variant="outlined"
+        sx={{ mb: 2 }}
+      />
+      <Box sx={{ 
+        display: 'flex', 
+        flexWrap: 'wrap', 
+        gap: 1 
+      }}>
+        {keywords.map((keyword) => (
+          <Chip
+            key={keyword}
+            label={keyword}
+            onDelete={() => onDelete(keyword)}
+            color="primary"
+            variant="outlined"
+          />
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+export default KeywordInput;

--- a/src/components/posts/upload/LinkInput.js
+++ b/src/components/posts/upload/LinkInput.js
@@ -1,0 +1,119 @@
+import React, { useState } from 'react';
+import { 
+  Typography, 
+  Box, 
+  Button, 
+  TextField, 
+  List, 
+  ListItem, 
+  IconButton
+} from '@mui/material';
+import {
+  Add as AddIcon,
+  Close as CloseIcon
+} from '@mui/icons-material';
+
+/**
+ * 링크 입력 컴포넌트
+ */
+const LinkInput = ({ links, onAddLink, onRemoveLink }) => {
+  const [newLink, setNewLink] = useState('');
+  const [newLinkDescription, setNewLinkDescription] = useState('');
+
+  const handleLinkAdd = (e) => {
+    e.preventDefault();
+    
+    if (!newLink.trim()) return;
+
+    // URL 형식 검증 및 https:// 추가
+    let formattedUrl = newLink.trim();
+    if (!formattedUrl.startsWith('http://') && !formattedUrl.startsWith('https://')) {
+      formattedUrl = `https://${formattedUrl}`;
+    }
+
+    // 링크 타입 자동 감지
+    const type = formattedUrl.includes('github.com') ? 'GITHUB'
+                : formattedUrl.includes('youtube.com') ? 'YOUTUBE'
+                : 'WEBSITE';
+    
+    // 새 링크 추가
+    onAddLink({
+      linkId: `link-${Date.now()}-${Math.random()}`,
+      url: formattedUrl,
+      title: newLinkDescription.trim() || formattedUrl,
+      type
+    });
+
+    // 입력 필드 초기화
+    setNewLink('');
+    setNewLinkDescription('');
+  };
+
+  return (
+    <Box sx={{ mb: 4 }}>
+      <Typography variant="h6" gutterBottom>
+        링크 추가
+      </Typography>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <TextField
+          fullWidth
+          type="url"
+          value={newLink}
+          onChange={(e) => setNewLink(e.target.value)}
+          placeholder="URL을 입력하세요"
+          variant="outlined"
+        />
+        <TextField
+          fullWidth
+          value={newLinkDescription}
+          onChange={(e) => setNewLinkDescription(e.target.value)}
+          placeholder="링크 설명을 입력하세요"
+          variant="outlined"
+        />
+        <Button
+          onClick={handleLinkAdd}
+          variant="outlined"
+          startIcon={<AddIcon />}
+          sx={{ alignSelf: 'flex-end' }}
+          disabled={!newLink.trim()}
+        >
+          링크 추가
+        </Button>
+      </Box>
+
+      {links.length > 0 && (
+        <List sx={{ mt: 2 }}>
+          {links.map((link) => (
+            <ListItem 
+              key={link.linkId}
+              sx={{ 
+                bgcolor: 'grey.50',
+                borderRadius: 1,
+                mb: 1
+              }}
+            >
+              <Box sx={{ 
+                display: 'flex', 
+                flexDirection: 'column',
+                flex: 1
+              }}>
+                <Typography>{link.url}</Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {link.title}
+                </Typography>
+              </Box>
+              <IconButton 
+                onClick={() => onRemoveLink(link.linkId)}
+                sx={{ color: 'error.main' }}
+              >
+                <CloseIcon />
+              </IconButton>
+            </ListItem>
+          ))}
+        </List>
+      )}
+    </Box>
+  );
+};
+
+export default LinkInput;

--- a/src/components/posts/upload/MarkdownEditor.js
+++ b/src/components/posts/upload/MarkdownEditor.js
@@ -1,0 +1,285 @@
+import React, { useState, useRef } from 'react';
+import { 
+  Typography, 
+  Box, 
+  Grid, 
+  TextField, 
+  Button,
+  Divider 
+} from '@mui/material';
+import ReactMarkdown from 'react-markdown';
+
+/**
+ * 마크다운 에디터 컴포넌트 - 에디터와 미리보기 기능 제공
+ */
+const MarkdownEditor = ({ 
+  value, 
+  onChange, 
+  placeholder = "마크다운으로 내용을 작성해주세요. 이미지나 PDF 파일을 드래그하여 추가할 수 있습니다.",
+  required = true,
+  onDrop
+}) => {
+  const textAreaRef = useRef(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  // 드래그 & 드롭 핸들러
+  const handleDragEnter = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(true);
+  };
+  
+  const handleDragLeave = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(false);
+  };
+  
+  const handleDragOver = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+  
+  const handleDrop = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(false);
+    if (onDrop) onDrop(e, textAreaRef);
+  };
+
+  // 마크다운 구문 삽입
+  const insertMarkdownSyntax = (syntax) => {
+    const textArea = textAreaRef.current;
+    if (!textArea) return;
+  
+    const start = textArea.selectionStart;
+    const end = textArea.selectionEnd;
+    const selectedText = value.substring(start, end);
+    let insertText = '';
+  
+    switch(syntax) {
+      case 'bold':
+        insertText = `**${selectedText || '굵은 텍스트'}**`;
+        break;
+      case 'italic':
+        insertText = `*${selectedText || '기울임 텍스트'}*`;
+        break;
+      case 'strikethrough':
+        insertText = `~~${selectedText || '취소선 텍스트'}~~`;
+        break;
+      case 'code':
+        insertText = selectedText.includes('\n') 
+          ? `\`\`\`\n${selectedText || '코드 블록'}\n\`\`\``
+          : `\`${selectedText || '인라인 코드'}\``;
+        break;
+      case 'link':
+        insertText = `[${selectedText || '링크 텍스트'}](url)`;
+        break;
+      case 'image':
+        insertText = `![${selectedText || '이미지 설명'}](이미지 URL)`;
+        break;
+      case 'heading':
+        insertText = `# ${selectedText || '제목'}`;
+        break;
+      case 'quote':
+        insertText = `> ${selectedText || '인용문'}`;
+        break;
+      case 'bullet':
+        insertText = selectedText
+          ? selectedText.split('\n').map(line => `- ${line}`).join('\n')
+          : '- 목록 항목';
+        break;
+      case 'number':
+        insertText = selectedText
+          ? selectedText.split('\n').map((line, i) => `${i + 1}. ${line}`).join('\n')
+          : '1. 목록 항목';
+        break;
+      default:
+        insertText = selectedText;
+    }
+  
+    const newContent = 
+      value.substring(0, start) +
+      insertText +
+      value.substring(end);
+  
+    // 변경 내용 부모 컴포넌트에 전달
+    onChange(newContent);
+  
+    // 커서 위치 조정
+    setTimeout(() => {
+      textArea.focus();
+      const newCursorPos = start + insertText.length;
+      textArea.setSelectionRange(newCursorPos, newCursorPos);
+    }, 0);
+  };
+
+  return (
+    <Grid container spacing={3}>
+      <Grid item xs={12} md={6}>
+        <Typography variant="h6" gutterBottom>
+          내용 작성
+        </Typography>
+        <Box
+          sx={{
+            position: 'relative',
+            '& .MuiTextField-root': {
+              backgroundColor: isDragging ? 'rgba(0, 102, 204, 0.05)' : 'transparent',
+            },
+          }}
+          onDragEnter={handleDragEnter}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+        >
+          <Box sx={{ 
+            mb: 2,
+            p: 1,
+            border: '1px solid',
+            borderColor: 'divider',
+            borderRadius: 1,
+            bgcolor: 'background.paper',
+            display: 'flex',
+            gap: 1,
+            flexWrap: 'wrap'
+          }}>
+            <Button
+              size="small"
+              variant="outlined"
+              onClick={() => insertMarkdownSyntax('bold')}
+              sx={{ minWidth: 'auto', px: 1 }}
+            >
+              <strong>B</strong>
+            </Button>
+            <Button
+              size="small"
+              variant="outlined"
+              onClick={() => insertMarkdownSyntax('italic')}
+              sx={{ minWidth: 'auto', px: 1 }}
+            >
+              <em>I</em>
+            </Button>
+            <Button
+              size="small"
+              variant="outlined"
+              onClick={() => insertMarkdownSyntax('strikethrough')}
+              sx={{ minWidth: 'auto', px: 1 }}
+            >
+              <span style={{ textDecoration: 'line-through' }}>S</span>
+            </Button>
+            <Divider orientation="vertical" flexItem />
+            <Button
+              size="small"
+              variant="outlined"
+              onClick={() => insertMarkdownSyntax('heading')}
+              sx={{ minWidth: 'auto', px: 1 }}
+            >
+              H
+            </Button>
+            <Button
+              size="small"
+              variant="outlined"
+              onClick={() => insertMarkdownSyntax('quote')}
+              sx={{ minWidth: 'auto', px: 1 }}
+            >
+              "
+            </Button>
+            <Button
+              size="small"
+              variant="outlined"
+              onClick={() => insertMarkdownSyntax('code')}
+              sx={{ minWidth: 'auto', px: 1 }}
+            >
+              {'</>'}
+            </Button>
+            <Divider orientation="vertical" flexItem />
+            <Button
+              size="small"
+              variant="outlined"
+              onClick={() => insertMarkdownSyntax('bullet')}
+              sx={{ minWidth: 'auto', px: 1 }}
+            >
+              •
+            </Button>
+            <Button
+              size="small"
+              variant="outlined"
+              onClick={() => insertMarkdownSyntax('number')}
+              sx={{ minWidth: 'auto', px: 1 }}
+            >
+              1.
+            </Button>
+            <Divider orientation="vertical" flexItem />
+            <Button
+              size="small"
+              variant="outlined"
+              onClick={() => insertMarkdownSyntax('link')}
+              sx={{ minWidth: 'auto', px: 1 }}
+            >
+              🔗
+            </Button>
+            <Button
+              size="small"
+              variant="outlined"
+              onClick={() => insertMarkdownSyntax('image')}
+              sx={{ minWidth: 'auto', px: 1 }}
+            >
+              🖼
+            </Button>
+          </Box>
+          {isDragging && (
+            <Box
+              sx={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: 'rgba(0, 102, 204, 0.1)',
+                border: '2px dashed #0066CC',
+                borderRadius: 1,
+                zIndex: 1,
+              }}
+            >
+              <Typography variant="body1" color="primary">
+                파일을 여기에 놓아주세요
+              </Typography>
+            </Box>
+          )}
+          <TextField
+            inputRef={textAreaRef}
+            fullWidth
+            multiline
+            rows={15}
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder={placeholder}
+            variant="outlined"
+            required={required}
+          />
+        </Box>
+      </Grid>
+      <Grid item xs={12} md={6}>
+        <Typography variant="h6" gutterBottom>
+          미리보기
+        </Typography>
+        <Box sx={{
+          height: '400px',
+          overflow: 'auto',
+          p: 2,
+          border: '1px solid',
+          borderColor: 'divider',
+          borderRadius: 1,
+          bgcolor: 'grey.50'
+        }}>
+          <ReactMarkdown>{value}</ReactMarkdown>
+        </Box>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default MarkdownEditor;

--- a/src/components/posts/upload/ThumbnailUploader.js
+++ b/src/components/posts/upload/ThumbnailUploader.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import { 
+  Typography, 
+  Box, 
+  Button, 
+  IconButton 
+} from '@mui/material';
+import {
+  Image as ImageIcon,
+  Close as CloseIcon
+} from '@mui/icons-material';
+
+/**
+ * 썸네일 이미지 업로더 컴포넌트
+ */
+const ThumbnailUploader = ({ thumbnail, onChange, onRemove }) => {
+  const handleThumbnailChange = (e) => {
+    const file = e.target.files[0];
+    if (file && file.type.startsWith('image/')) {
+      onChange(file);
+    } else {
+      alert('이미지 파일을 선택하세요.');
+    }
+  };
+
+  return (
+    <Box sx={{ mb: 4 }}>
+      <Typography variant="subtitle1" gutterBottom>
+        대표 이미지
+      </Typography>
+      <Box sx={{ 
+        border: '2px dashed',
+        borderColor: thumbnail ? 'primary.main' : 'grey.300',
+        borderRadius: 1,
+        p: 2,
+        position: 'relative',
+      }}>
+        {thumbnail ? (
+          <Box sx={{ position: 'relative' }}>
+            <img
+              src={thumbnail instanceof File ? URL.createObjectURL(thumbnail) : thumbnail}
+              alt="Thumbnail preview"
+              style={{
+                width: '100%',
+                height: '200px',
+                objectFit: 'cover',
+                borderRadius: '4px',
+              }}
+            />
+            <IconButton
+              onClick={onRemove}
+              sx={{
+                position: 'absolute',
+                top: 8,
+                right: 8,
+                bgcolor: 'background.paper',
+                '&:hover': { bgcolor: 'grey.100' },
+              }}
+            >
+              <CloseIcon />
+            </IconButton>
+          </Box>
+        ) : (
+          <Button
+            component="label"
+            sx={{
+              width: '100%',
+              height: '200px',
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 1,
+            }}
+          >
+            <input
+              type="file"
+              hidden
+              accept="image/*"
+              onChange={handleThumbnailChange}
+            />
+            <ImageIcon sx={{ fontSize: 40 }} />
+            <Typography>대표 이미지 추가</Typography>
+          </Button>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default ThumbnailUploader;

--- a/src/components/posts/view/BasePostView.js
+++ b/src/components/posts/view/BasePostView.js
@@ -125,7 +125,7 @@ const BasePostView = ({
           title={postData.title}
           subtitle={postData.subtitle}
           content={postData.content}
-          thumbnailUrl={postData.thumbnail}
+          thumbnailUrl={postData.thumbnail === 'markdown-image' ? null : postData.thumbnail}
           getDisplayImage={getDisplayImage}
         />
         

--- a/src/components/posts/view/PostContent.js
+++ b/src/components/posts/view/PostContent.js
@@ -56,20 +56,23 @@ const PostContent = ({
       </Box>
 
       {/* Thumbnail */}
-      {thumbnailUrl && (
+      {thumbnailUrl && thumbnailUrl !== 'markdown-image' && (
         <Box sx={{ 
           width: '100%',
-          height: '400px',
-          position: 'relative',
-          mb: 4
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          mb: 4,
+          padding: '20px 0'
         }}>
           <img
-            src={getDisplayImage ? getDisplayImage() : thumbnailUrl}
+            src={thumbnailUrl}
             alt="Post thumbnail"
             style={{
-              width: '100%',
-              height: '100%',
-              objectFit: 'cover',
+              maxWidth: '100%',
+              maxHeight: '600px',
+              objectFit: 'contain',
+              display: 'block'
             }}
           />
         </Box>

--- a/src/hooks/usePostUpload.js
+++ b/src/hooks/usePostUpload.js
@@ -1,0 +1,308 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { 
+  doc, 
+  getDoc, 
+  updateDoc, 
+  addDoc, 
+  collection, 
+  serverTimestamp 
+} from 'firebase/firestore';
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { db, storage } from '../firebase';
+
+/**
+ * 게시물 업로드 및 수정 기능을 제공하는 커스텀 훅
+ * @param {string} collectionName - 컬렉션 이름 (portfolios, labs, companies)
+ * @param {string} postId - 수정 시 사용할 게시물 ID (선택 사항)
+ * @param {Object} currentUser - 현재 로그인한 사용자 정보
+ */
+const usePostUpload = (collectionName, postId, currentUser) => {
+  const navigate = useNavigate();
+  
+  // 기본 정보 상태
+  const [title, setTitle] = useState('');
+  const [subtitle, setSubtitle] = useState('');
+  const [markdownContent, setMarkdownContent] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isPreview, setIsPreview] = useState(false);
+  
+  // 첨부 파일 관련 상태
+  const [thumbnail, setThumbnail] = useState(null);
+  const [files, setFiles] = useState([]);
+  const [links, setLinks] = useState([]);
+  const [keywords, setKeywords] = useState([]);
+  
+  // 초기 데이터 로딩 (수정 모드)
+  useEffect(() => {
+    const fetchPost = async () => {
+      if (postId && postId !== 'preview-id') {
+        try {
+          const postDoc = await getDoc(doc(db, collectionName, postId));
+          if (postDoc.exists()) {
+            const data = postDoc.data();
+            
+            // 기본 정보 설정
+            setTitle(data.title || '');
+            setSubtitle(data.subtitle || '');
+            setMarkdownContent(data.content || '');
+            setThumbnail(data.thumbnail || null);
+            setKeywords(data.keywords || []);
+            
+            // 파일 데이터 설정
+            if (data.files) {
+              setFiles(data.files.map(file => ({
+                ...file,
+                fileId: file.fileId || `file-${Date.now()}-${Math.random()}`
+              })));
+            }
+            
+            // 링크 데이터 설정
+            if (data.links) {
+              setLinks(data.links.map(link => ({
+                ...link,
+                linkId: link.linkId || `link-${Date.now()}-${Math.random()}`
+              })));
+            }
+          }
+        } catch (error) {
+          console.error('Error loading post:', error);
+        }
+      }
+    };
+  
+    fetchPost();
+  }, [postId, collectionName]);
+
+  // 파일 관련 핸들러
+  const handleDrop = (e, textAreaRef) => {
+    const files = Array.from(e.dataTransfer.files);
+    const validFiles = files.filter(file => 
+      file.type.startsWith('image/') || file.type === 'application/pdf'
+    );
+
+    if (validFiles.length > 0 && textAreaRef.current) {
+      const cursorPosition = textAreaRef.current.selectionStart;
+      
+      for (const file of validFiles) {
+        const markdown = file.type === 'application/pdf' 
+          ? `[PDF: ${file.name}](${URL.createObjectURL(file)})\n`
+          : `![${file.name}](${URL.createObjectURL(file)})\n`;
+        
+        const newContent = markdownContent.slice(0, cursorPosition) + 
+                    markdown + 
+                    markdownContent.slice(cursorPosition);
+        
+        setMarkdownContent(newContent);
+        
+        const fileType = file.type.startsWith('image/') ? 'IMAGE' : 'PDF';
+        handleAddFile({
+          fileId: `file-${Date.now()}-${Math.random()}`,
+          file: file,
+          type: fileType,
+          description: ''
+        });
+      }
+    }
+  };
+
+  // 파일 추가
+  const handleAddFile = (fileData) => {
+    setFiles(prev => [...prev, fileData]);
+  };
+
+  // 파일 설명 업데이트
+  const handleUpdateFileDescription = (fileId, description) => {
+    setFiles(prev => prev.map(file => 
+      file.fileId === fileId ? { ...file, description } : file
+    ));
+  };
+
+  // 파일 삭제
+  const handleRemoveFile = (fileId) => {
+    setFiles(prev => prev.filter(file => file.fileId !== fileId));
+  };
+
+  // 링크 추가
+  const handleAddLink = (linkData) => {
+    setLinks(prev => [...prev, linkData]);
+  };
+
+  // 링크 삭제
+  const handleRemoveLink = (linkId) => {
+    setLinks(prev => prev.filter(link => link.linkId !== linkId));
+  };
+
+  // 키워드 추가
+  const handleAddKeyword = (keyword) => {
+    setKeywords(prev => [...prev, keyword]);
+  };
+
+  // 키워드 삭제
+  const handleRemoveKeyword = (keyword) => {
+    setKeywords(prev => prev.filter(kw => kw !== keyword));
+  };
+
+  // 썸네일 설정
+  const handleSetThumbnail = (file) => {
+    setThumbnail(file);
+  };
+
+  // 썸네일 삭제
+  const handleRemoveThumbnail = () => {
+    setThumbnail(null);
+  };
+
+  // 게시물 제출 (저장/수정)
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+
+    if (isSubmitting || !currentUser) {
+      return;
+    }
+    
+    try {
+      setIsSubmitting(true);
+      
+      // 1. 썸네일 처리
+      let thumbnailUrl = thumbnail;
+
+      // 썸네일이 없는 경우 첫 번째 이미지를 썸네일로 사용
+      if (!thumbnail) {
+        const imageFile = files.find(fileItem => fileItem.type === 'IMAGE' && fileItem.file);
+        if (imageFile) {
+          const thumbnailRef = ref(storage, `thumbnails/${currentUser.uid}/${Date.now()}-${imageFile.file.name}`);
+          const thumbnailSnapshot = await uploadBytes(thumbnailRef, imageFile.file);
+          thumbnailUrl = await getDownloadURL(thumbnailSnapshot.ref);
+        }
+      } 
+      // 새로운 썸네일이 File 객체인 경우 업로드
+      else if (thumbnail instanceof File) {
+        const thumbnailRef = ref(storage, `thumbnails/${currentUser.uid}/${Date.now()}-${thumbnail.name}`);
+        const thumbnailSnapshot = await uploadBytes(thumbnailRef, thumbnail);
+        thumbnailUrl = await getDownloadURL(thumbnailSnapshot.ref);
+      }
+
+      // 2. 파일 업로드
+      const uploadedFiles = await Promise.all(
+        files.map(async (fileItem) => {
+          // 이미 업로드된 파일은 그대로 사용
+          if (fileItem.url) {
+            return fileItem;
+          }
+          
+          // 새로운 파일 업로드
+          const fileRef = ref(storage, `files/${currentUser.uid}/${Date.now()}-${fileItem.file.name}`);
+          const fileSnapshot = await uploadBytes(fileRef, fileItem.file);
+          const url = await getDownloadURL(fileSnapshot.ref);
+          
+          return {
+            fileId: fileItem.fileId,
+            url: url,
+            filename: fileItem.file.name,
+            type: fileItem.type,
+            description: fileItem.description
+          };
+        })
+      );
+
+      // 3. 게시물 데이터 준비
+      const updatedData = {
+        title,
+        subtitle,
+        content: markdownContent,
+        files: uploadedFiles,
+        links,
+        thumbnail: thumbnailUrl,
+        keywords,
+        updatedAt: serverTimestamp()
+      };
+
+      // 4. 게시물 저장 또는 수정
+      if (postId && postId !== 'preview-id') {
+        // 수정 모드
+        await updateDoc(doc(db, collectionName, postId), updatedData);
+        alert('게시글이 수정되었습니다.');
+        navigate(`/${collectionName}/${postId}`);
+      } else {
+        // 새 게시물 작성 모드
+        updatedData.authorId = currentUser.uid;
+        updatedData.likeCount = 0;
+        updatedData.commentCount = 0;
+        updatedData.createdAt = serverTimestamp();
+        
+        const docRef = await addDoc(collection(db, collectionName), updatedData);
+        alert('게시글이 작성되었습니다.');
+        navigate(`/${collectionName}/${docRef.id}`);
+      }
+    } catch (error) {
+      console.error('Error submitting post:', error);
+      alert(`업로드 중 오류 발생: ${error.message}`);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // 미리보기 토글
+  const togglePreview = () => {
+    setIsPreview(prev => !prev);
+  };
+
+  // 데이터를 객체로 반환
+  return {
+    // 기본 정보 상태 및 설정
+    title,
+    setTitle,
+    subtitle,
+    setSubtitle,
+    markdownContent,
+    setMarkdownContent,
+    isSubmitting,
+    isPreview,
+    togglePreview,
+    
+    // 파일 및 메타데이터 상태
+    thumbnail,
+    files,
+    links,
+    keywords,
+    
+    // 핸들러 함수
+    handleDrop,
+    handleAddFile,
+    handleUpdateFileDescription,
+    handleRemoveFile,
+    handleAddLink,
+    handleRemoveLink,
+    handleAddKeyword,
+    handleRemoveKeyword,
+    handleSetThumbnail,
+    handleRemoveThumbnail,
+    handleSubmit,
+    
+    // 미리보기용 데이터
+    previewData: {
+      postId: postId || 'preview-id',
+      authorId: currentUser?.uid,
+      title,
+      subtitle,
+      content: markdownContent,
+      files,
+      links,
+      likeCount: 0,
+      commentCount: 0,
+      thumbnail,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      keywords
+    },
+    previewAuthor: currentUser ? {
+      id: currentUser.uid,
+      displayName: currentUser.displayName,
+      profileImage: currentUser.photoURL,
+      role: currentUser.role || 'STUDENT'
+    } : null
+  };
+};
+
+export default usePostUpload;


### PR DESCRIPTION
## 변경 사항
- 썸네일 이미지가 잘리는 문제 해결 (objectFit: 'contain' 적용)
- 배경색 및 이미지 컨테이너 스타일 개선으로 가시성 향상
- 마크다운 콘텐츠 내 이미지 링크를 자동으로 썸네일로 활용하는 기능 구현
- 마크다운 이미지와 썸네일 간 중복 표시 방지 로직 추가

## 작동 방식
1. 등록된 썸네일이 있으면 그것을 사용
2. 없으면 첨부 파일 중 이미지 파일을 사용
3. 그것도 없으면 마크다운 내용에서 첫 번째 이미지를 찾아 카드 썸네일로만 사용
4. 모두 없으면 기본 이미지를 사용
